### PR TITLE
Add preview image to post body

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -73,7 +73,7 @@ start_date: ${startDate} ${startTime}
 # End date and time (defaults to one hour after start). Used for calendar page.
 end_date: ${endDate} ${endTime}
 ---
-
+${previewImage && previewImage[0] ? `\n![Preview image for ${title} event](${getFileName(previewImage[0].name, prefixDate)})\n` : ""}
 ${body}
 `
   );


### PR DESCRIPTION
This PR adds Markdown for adding the preview image to the body of the generated event if such a preview image is provided.

Previously, event pages would only show the body text, and the preview image would only be shown on the cards on the homepage. PRs would be generated [like so](https://github.com/ubccsss/ubccsss.org/pull/487), and adding the preview image to the event page itself was a manual process.